### PR TITLE
Add setting for disabling Dramatic Rolls for GM and NPCs

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,6 +1,6 @@
 const constants = {
     modName: 'dramatic-rolls',
-    debugMode: true
+    debugMode: false
 };
 
 export default constants;

--- a/constants.js
+++ b/constants.js
@@ -1,6 +1,6 @@
 const constants = {
     modName: 'dramatic-rolls',
-    debugMode: false
+    debugMode: true
 };
 
 export default constants;

--- a/lang/en.json
+++ b/lang/en.json
@@ -12,6 +12,10 @@
             "configure-sounds": {
                 "name": "Configure Sounds",
                 "label": "Configure which sounds play on crits and fumbles"
+            },
+            "disable-npc-rolls": {
+                "name": "Disable Dramatic Rolls for NPCs and GM",
+                "label": "Let the players have their fun, dramatic rolls will only trigger for players and actors that have a player owner."
             }
         },
         "settings-form": {

--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
       "url": "https://github.com/gsimon2"
     }
   ],
-  "version": "1.1.0",
+  "version": "1.2.0",
   "minimumCoreVersion": "0.7.0",
   "compatibleCoreVersion": "0.7.9",
   "esmodules": ["scripts/main.js"],
@@ -24,7 +24,7 @@
   "url": "https://github.com/gsimon2/dramatic-rolls",
   "bugs": "https://github.com/gsimon2/dramatic-rolls/issues",
 	"changelog": "https://github.com/gsimon2/dramatic-rolls/releases",
-	"download": "https://github.com/gsimon2/dramatic-rolls/releases/download/1.1.0/module.zip",
-	"manifest": "https://github.com/gsimon2/dramatic-rolls/releases/download/1.1.0/module.json",
+	"download": "https://github.com/gsimon2/dramatic-rolls/releases/download/1.2.0/module.zip",
+	"manifest": "https://github.com/gsimon2/dramatic-rolls/releases/download/1.2.0/module.json",
 	"readme": "https://raw.githubusercontent.com/gsimon2/dramatic-rolls/main/README.md"
 }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -33,6 +33,15 @@ export const registerSettings = () => {
         type: Object,
         config: false
     });
+
+    game.settings.register(constants.modName, 'disable-npc-rolls', {
+        name: 'dramatic-rolls.settings.disable-npc-rolls.name',
+        hint: 'dramatic-rolls.settings.disable-npc-rolls.label',
+        scope: 'world',
+        config: true,
+        default: false,
+        type: Boolean,
+    });
 };
 
 export const registerConfettiSetting = () => {


### PR DESCRIPTION
Allows for dramatic rolls to only trigger for players and actors that have a player owner.