### PR TITLE
Release compatible version for Foundry `0.8.x`

### DIFF
--- a/module.json
+++ b/module.json
@@ -9,9 +9,9 @@
       "url": "https://github.com/gsimon2"
     }
   ],
-  "version": "1.3.0",
-  "minimumCoreVersion": "0.7.0",
-  "compatibleCoreVersion": "0.7.9",
+  "version": "1.4.0",
+  "minimumCoreVersion": "0.8.6",
+  "compatibleCoreVersion": "0.8.6",
   "esmodules": ["scripts/main.js"],
   "styles": ["styles/dramaticRolls.css"],
   "languages": [
@@ -24,7 +24,7 @@
   "url": "https://github.com/gsimon2/dramatic-rolls",
   "bugs": "https://github.com/gsimon2/dramatic-rolls/issues",
 	"changelog": "https://github.com/gsimon2/dramatic-rolls/releases",
-	"download": "https://github.com/gsimon2/dramatic-rolls/releases/download/1.3.0/module.zip",
-	"manifest": "https://github.com/gsimon2/dramatic-rolls/releases/download/1.3.0/module.json",
+	"download": "https://github.com/gsimon2/dramatic-rolls/releases/download/1.4.0/module.zip",
+	"manifest": "https://github.com/gsimon2/dramatic-rolls/releases/download/1.4.0/module.json",
 	"readme": "https://raw.githubusercontent.com/gsimon2/dramatic-rolls/main/README.md"
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -43,7 +43,7 @@ Hooks.on('ready', () => {
                     const usedDice = [...diceRolls].filter(node => !node.classList.contains('qr-discarded'))[0];
                     const rollFormula = usedDice.querySelector('div.dice-formula')?.textContent;
                     const rollResult = usedDice.querySelector('li.roll.d20')?.textContent;
-    
+
                     if (rollFormula && !disableDueToNPC(msg.data.speaker)) {
                         let roll = new Roll(rollFormula);
                         roll.results = [rollResult];
@@ -92,9 +92,14 @@ const disableDueToNPC = (speaker) => {
     return  settingEnabld && (!actorHasPlayerOwner && isGM);
 };
 
+const getActiveResults = (roll) => {
+    return roll.terms.reduce((acc, term) => acc.concat(term?.results), []).filter(result => result.active).map(result => result.result);
+};
+
 const isCrit = (roll) => {
+    getActiveResults(roll);
     if (roll._formula.includes('d20')) {
-        if (roll.results[0] == 20 || constants.debugMode) {
+        if (getActiveResults(roll).includes(20) || constants.debugMode) {
             return true;
         }
     }
@@ -103,7 +108,7 @@ const isCrit = (roll) => {
 
 const isFumble = (roll) => {
     if (roll._formula.includes('d20')) {
-        if (roll.results[0] == 1) {
+        if (getActiveResults(roll).includes(1)) {
             return true;
         }
     }


### PR DESCRIPTION
The structure of the roll object changed with Foundry version `0.8.x` and broke functionality. This PR makes it compatible with stable `0.8.x` releases (testing on `0.8.6`) but will not be backwards compatible with `0.7.x` or lower.

Fixes: https://github.com/gsimon2/dramatic-rolls/issues/12