### PR TITLE
Allow sound effects to have adjustable volumes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -32,7 +32,8 @@
             "addCritSound": "Add Critical Sound Effect",
             "addFumbleSound": "Add Fumble Sound Effect",
             "critical-sounds-list-title": "Critical Sound Effects",
-            "fumble-sounds-list-title": "Fumble Sound Effects"
+            "fumble-sounds-list-title": "Fumble Sound Effects",
+            "soundVolume": "Volume"
         }
     }
 }

--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
       "url": "https://github.com/gsimon2"
     }
   ],
-  "version": "1.5.0",
+  "version": "1.6.0",
   "minimumCoreVersion": "9",
   "compatibleCoreVersion": "9.249",
   "esmodules": ["scripts/main.js"],
@@ -24,7 +24,7 @@
   "url": "https://github.com/gsimon2/dramatic-rolls",
   "bugs": "https://github.com/gsimon2/dramatic-rolls/issues",
 	"changelog": "https://github.com/gsimon2/dramatic-rolls/releases",
-	"download": "https://github.com/gsimon2/dramatic-rolls/releases/download/1.5.0/module.zip",
-	"manifest": "https://github.com/gsimon2/dramatic-rolls/releases/download/1.5.0/module.json",
+	"download": "https://github.com/gsimon2/dramatic-rolls/releases/download/1.6.0/module.zip",
+	"manifest": "https://github.com/gsimon2/dramatic-rolls/releases/download/1.6.0/module.json",
 	"readme": "https://raw.githubusercontent.com/gsimon2/dramatic-rolls/main/README.md"
 }

--- a/module.json
+++ b/module.json
@@ -10,8 +10,8 @@
     }
   ],
   "version": "1.5.0",
-  "minimumCoreVersion": "0.8.6",
-  "compatibleCoreVersion": "0.8.8",
+  "minimumCoreVersion": "9",
+  "compatibleCoreVersion": "9.249",
   "esmodules": ["scripts/main.js"],
   "styles": ["styles/dramaticRolls.css"],
   "languages": [

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -149,10 +149,10 @@ const handleEffects = (roll, isPublic = true) => {
 const playSound = (roll, broadcastSound) => {
     const soundEffect = roll.soundEffect;
 
-    if (soundEffect) {
+    if (soundEffect && soundEffect.path) {
         AudioHelper.play({
-            src: soundEffect,
-            volume: 0.8,
+            src: soundEffect.path,
+            volume: soundEffect.volume,
             autoplay: true,
             loop: false
         }, broadcastSound);

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -3,8 +3,8 @@ import {DramaticRollsSettingsForm} from './settingsForm.js';
 import soundEffectController from './soundEffectController.js';
 
 export const defaultSettings = {
-    critSounds: soundEffectController.critSoundEffectFiles.map(soundFilePath => ({enabled: true, path: soundFilePath, isUserAddedSound: false})),
-    fumbleSounds: soundEffectController.fumbleSoundEffectFiles.map(soundFilePath => ({enabled: true, path: soundFilePath, isUserAddedSound: false}))
+    critSounds: soundEffectController.critSoundEffectFiles.map(soundFilePath => ({enabled: true, path: soundFilePath, isUserAddedSound: false, volume: 0.8})),
+    fumbleSounds: soundEffectController.fumbleSoundEffectFiles.map(soundFilePath => ({enabled: true, path: soundFilePath, isUserAddedSound: false, volume: 0.8}))
 };
 
 export const registerSettings = () => {

--- a/scripts/soundEffectController.js
+++ b/scripts/soundEffectController.js
@@ -40,14 +40,14 @@ const getCritSoundEffect = () => {
     const sounds = game.settings.get(constants.modName, 'settings').critSounds;
     const enabledSounds = sounds.filter(s => s.enabled);
     const selectedSound = enabledSounds[getRandomInt(enabledSounds.length)];
-    return selectedSound?.path || "";
+    return selectedSound;
 };
 
 const getFumbleSoundEffect = () => {
     const sounds = game.settings.get(constants.modName, 'settings').fumbleSounds;
     const enabledSounds = sounds.filter(s => s.enabled);
     const selectedSound = enabledSounds[getRandomInt(enabledSounds.length)];
-    return selectedSound?.path || "";
+    return selectedSound;
 };
 
 export default {

--- a/styles/dramaticRolls.css
+++ b/styles/dramaticRolls.css
@@ -27,6 +27,7 @@
 
 .dramatic-rolls.setting-form .sound-option-group .volume-slider {
     padding-right: 0.5rem;
+    margin-top: 2px;
 }
 
 .dramatic-rolls.setting-form .sound-option-group .volume-display {

--- a/styles/dramaticRolls.css
+++ b/styles/dramaticRolls.css
@@ -10,6 +10,28 @@
 .dramatic-rolls.setting-form .sound-option-group {
     flex-wrap: nowrap;
     padding-bottom: 0.5rem;
+    flex-direction: column;
+}
+
+.dramatic-rolls.setting-form .sound-option-group .group-line {
+    width: 100%;
+    display: flex;
+}
+
+.dramatic-rolls.setting-form .sound-option-group .volume-label {
+    height: 1.5rem;
+    line-height: 1rem;
+    white-space: nowrap;
+    padding: 0.25rem 0.5rem;
+}
+
+.dramatic-rolls.setting-form .sound-option-group .volume-slider {
+    padding-right: 0.5rem;
+}
+
+.dramatic-rolls.setting-form .sound-option-group .volume-display {
+    width: 46px;
+    margin: 0 0.375rem;
 }
 
 .dramatic-rolls.setting-form .list-header {

--- a/templates/settings-form.handlebars
+++ b/templates/settings-form.handlebars
@@ -5,17 +5,23 @@
         <ul id="crit-sounds-list">
             {{#each critSounds}}
                 <li class="form-group sound-option-group">
-                    <input type="checkbox" name="critEnabled" data-dtype="Boolean" {{checked this.enabled}} title="{{localize "dramatic-rolls.settings-form.enableDisableSound"}}" />
-                    <input type="text" data-dtype="String" class="sound-path-input" value={{this.path}} title="{{this.path}}" readonly />
-                    {{#if this.isUserAddedSound}}
-                        <button id="delete-crit-sound-{{@index}}" title="{{localize "dramatic-rolls.settings-form.removeSound"}}">
-                            <i class="fas fa-minus-circle"></i>
+                    <div class="group-line">
+                        <input type="checkbox" name="critEnabled" data-dtype="Boolean" {{checked this.enabled}} title="{{localize "dramatic-rolls.settings-form.enableDisableSound"}}" />
+                        <input type="text" data-dtype="String" class="sound-path-input" value={{this.path}} title="{{this.path}}" readonly />
+                        {{#if this.isUserAddedSound}}
+                            <button id="delete-crit-sound-{{@index}}" title="{{localize "dramatic-rolls.settings-form.removeSound"}}">
+                                <i class="fas fa-minus-circle"></i>
+                            </button>
+                        {{/if}}
+                        <button id="play-crit-sound-{{@index}}" title="{{localize "dramatic-rolls.settings-form.playSound"}}">
+                            <i class="fas fa-play-circle"></i>
                         </button>
-                    {{/if}}
-                    <button id="play-crit-sound-{{@index}}" title="{{localize "dramatic-rolls.settings-form.playSound"}}">
-                        <i class="fas fa-play-circle"></i>
-                    </button>
-
+                    </div>
+                    <div class="group-line">
+                        <label class="volume-label">{{localize "dramatic-rolls.settings-form.soundVolume"}}</label>
+                        <input type="range" name="crit-volume" id="crit-sound-volume-{{@index}}" min="0" max="1" step="0.01" class="volume-slider" value="{{this.volume}}"/>
+                        <input type="text" class="volume-display" readonly value="{{this.volume}}" />
+                    </div>
                 </li>
             {{/each}}
         </ul>
@@ -27,16 +33,23 @@
         <ul id="fumble-sounds-list">
             {{#each fumbleSounds}}
                 <li class="form-group sound-option-group">
-                    <input type="checkbox" name="fumbleEnabled" data-dtype="Boolean" {{checked this.enabled}} title="{{localize "dramatic-rolls.settings-form.enableDisableSound"}}" />
-                    <input type="text" data-dtype="String" class="sound-path-input" readonly value={{this.path}} title="{{this.path}}" readonly />
-                    {{#if this.isUserAddedSound}}
-                        <button id="delete-fumble-sound-{{@index}}" title="{{localize "dramatic-rolls.settings-form.removeSound"}}">
-                            <i class="fas fa-minus-circle"></i>
+                    <div class="group-line">
+                        <input type="checkbox" name="fumbleEnabled" data-dtype="Boolean" {{checked this.enabled}} title="{{localize "dramatic-rolls.settings-form.enableDisableSound"}}" />
+                        <input type="text" data-dtype="String" class="sound-path-input" readonly value={{this.path}} title="{{this.path}}" readonly />
+                        {{#if this.isUserAddedSound}}
+                            <button id="delete-fumble-sound-{{@index}}" title="{{localize "dramatic-rolls.settings-form.removeSound"}}">
+                                <i class="fas fa-minus-circle"></i>
+                            </button>
+                        {{/if}}
+                        <button id="play-fumble-sound-{{@index}}" title="{{localize "dramatic-rolls.settings-form.playSound"}}">
+                            <i class="fas fa-play-circle"></i>
                         </button>
-                    {{/if}}
-                    <button id="play-fumble-sound-{{@index}}" title="{{localize "dramatic-rolls.settings-form.playSound"}}">
-                        <i class="fas fa-play-circle"></i>
-                    </button>
+                    </div>
+                    <div class="group-line">
+                        <label class="volume-label">{{localize "dramatic-rolls.settings-form.soundVolume"}}</label>
+                        <input type="range" name="fumble-volume" id="fumble-sound-volume-{{@index}}" min="0" max="1" step="0.01" class="volume-slider" value="{{this.volume}}"/>
+                        <input type="text" class="volume-display" readonly value="{{this.volume}}" />
+                    </div>
                 </li>
             {{/each}}
         </ul>

--- a/templates/settings-form.handlebars
+++ b/templates/settings-form.handlebars
@@ -6,7 +6,7 @@
             {{#each critSounds}}
                 <li class="form-group sound-option-group">
                     <div class="group-line">
-                        <input type="checkbox" name="critEnabled" data-dtype="Boolean" {{checked this.enabled}} title="{{localize "dramatic-rolls.settings-form.enableDisableSound"}}" />
+                        <input type="checkbox" name="critEnabled" id="enable-crit-sound-{{@index}}" data-dtype="Boolean" {{checked this.enabled}} title="{{localize "dramatic-rolls.settings-form.enableDisableSound"}}" />
                         <input type="text" data-dtype="String" class="sound-path-input" value={{this.path}} title="{{this.path}}" readonly />
                         {{#if this.isUserAddedSound}}
                             <button id="delete-crit-sound-{{@index}}" title="{{localize "dramatic-rolls.settings-form.removeSound"}}">
@@ -20,7 +20,7 @@
                     <div class="group-line">
                         <label class="volume-label">{{localize "dramatic-rolls.settings-form.soundVolume"}}</label>
                         <input type="range" name="crit-volume" id="crit-sound-volume-{{@index}}" min="0" max="1" step="0.01" class="volume-slider" value="{{this.volume}}"/>
-                        <input type="text" class="volume-display" readonly value="{{this.volume}}" />
+                        <input type="text" class="volume-display" id="crit-sound-volume-{{@index}}-display" readonly value="{{this.volume}}" />
                     </div>
                 </li>
             {{/each}}
@@ -34,7 +34,7 @@
             {{#each fumbleSounds}}
                 <li class="form-group sound-option-group">
                     <div class="group-line">
-                        <input type="checkbox" name="fumbleEnabled" data-dtype="Boolean" {{checked this.enabled}} title="{{localize "dramatic-rolls.settings-form.enableDisableSound"}}" />
+                        <input type="checkbox" name="fumbleEnabled" id="enable-fumble-sound-{{@index}}" data-dtype="Boolean" {{checked this.enabled}} title="{{localize "dramatic-rolls.settings-form.enableDisableSound"}}" />
                         <input type="text" data-dtype="String" class="sound-path-input" readonly value={{this.path}} title="{{this.path}}" readonly />
                         {{#if this.isUserAddedSound}}
                             <button id="delete-fumble-sound-{{@index}}" title="{{localize "dramatic-rolls.settings-form.removeSound"}}">
@@ -48,7 +48,7 @@
                     <div class="group-line">
                         <label class="volume-label">{{localize "dramatic-rolls.settings-form.soundVolume"}}</label>
                         <input type="range" name="fumble-volume" id="fumble-sound-volume-{{@index}}" min="0" max="1" step="0.01" class="volume-slider" value="{{this.volume}}"/>
-                        <input type="text" class="volume-display" readonly value="{{this.volume}}" />
+                        <input type="text" class="volume-display" id="fumble-sound-volume-{{@index}}-display" readonly value="{{this.volume}}" />
                     </div>
                 </li>
             {{/each}}


### PR DESCRIPTION
Adds a configurable volume level to each sound effect. This is set in the settings submenu.
Cleans up some of the state management logic in the settings submenu.

Fixes: https://github.com/gsimon2/dramatic-rolls/issues/16

![image](https://user-images.githubusercontent.com/20954654/153267569-fb86cf99-45a3-4a76-b42a-799ac5f49a75.png)
