### PR TITLE
Add built-in confetti support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dramatic-rolls.lock

--- a/README.md
+++ b/README.md
@@ -13,9 +13,6 @@ By default this module comes with a sets of sounds that will be triggered on eit
 - Compatible with the [Dice So Nice!](https://foundryvtt.com/packages/dice-so-nice/) module. Holds the additional effects until the rolling animation is completed.
   - Note: Dice So Nice now has native support for special effects on specific die rolls, please check that out as it captures the intention of this repo. They can still be used together though for a wider array of effects!
 
-- Compatible with the [Confetti](https://foundryvtt.com/packages/confetti/) module. Triggers the confetti effect on natural 20s.
-
 
 ## Upcoming Features (Maybe)
-- Adding visual effects that do not rely on the [Confetti](https://foundryvtt.com/packages/confetti/) module.
 - Adding effects for min / max damage rolls.

--- a/constants.js
+++ b/constants.js
@@ -1,6 +1,6 @@
 const constants = {
    modName: "dramatic-rolls",
-   debugMode: false,
+   debugMode: true,
 };
 
 export default constants;

--- a/constants.js
+++ b/constants.js
@@ -1,6 +1,6 @@
 const constants = {
    modName: "dramatic-rolls",
-   debugMode: true,
+   debugMode: false,
 };
 
 export default constants;

--- a/lang/en.json
+++ b/lang/en.json
@@ -6,8 +6,8 @@
                 "label": "Add sound effects to critical successes and critical failures (fumbles)."
             },
             "add-confetti": {
-                "name": "Add confetti to natural twenties",
-                "label": ""
+                "name": "Add confetti to criticals",
+                "label": "Recommend disabling this for slower computers"
             },
             "configure-sounds": {
                 "name": "Configure Sounds",

--- a/module.json
+++ b/module.json
@@ -25,6 +25,7 @@
       "flags": {}
     }
   ],
+  "socket": true,
   "url": "https://github.com/gsimon2/dramatic-rolls",
   "bugs": "https://github.com/gsimon2/dramatic-rolls/issues",
   "changelog": "https://github.com/gsimon2/dramatic-rolls/releases",

--- a/module.json
+++ b/module.json
@@ -9,7 +9,7 @@
       "flags": {}
     }
   ],
-  "version": "2.1.1",
+  "version": "2.2.0",
   "esmodules": [
     "scripts/main.js",
     "greensock/esm/all.js"
@@ -29,8 +29,8 @@
   "url": "https://github.com/gsimon2/dramatic-rolls",
   "bugs": "https://github.com/gsimon2/dramatic-rolls/issues",
   "changelog": "https://github.com/gsimon2/dramatic-rolls/releases",
-  "download": "https://github.com/gsimon2/dramatic-rolls/releases/download/2.1.1/module.zip",
-  "manifest": "https://github.com/gsimon2/dramatic-rolls/releases/download/2.1.1/module.json",
+  "download": "https://github.com/gsimon2/dramatic-rolls/releases/download/2.2.0/module.zip",
+  "manifest": "https://github.com/gsimon2/dramatic-rolls/releases/download/2.2.0/module.json",
   "readme": "https://raw.githubusercontent.com/gsimon2/dramatic-rolls/main/README.md",
   "id": "dramatic-rolls",
   "compatibility": {

--- a/module.json
+++ b/module.json
@@ -11,7 +11,8 @@
   ],
   "version": "2.1.1",
   "esmodules": [
-    "scripts/main.js"
+    "scripts/main.js",
+    "greensock/esm/all.js"
   ],
   "styles": [
     "styles/dramaticRolls.css"

--- a/scripts/confetti.js
+++ b/scripts/confetti.js
@@ -116,7 +116,7 @@ export function setupConfetti() {
     });
   }
     
-  document.querySelector('body').onclick = function () {
-   fireConfetti();
-  };
+//   document.querySelector('body').onclick = function () {
+//    fireConfetti();
+//   };
 }

--- a/scripts/confetti.js
+++ b/scripts/confetti.js
@@ -1,0 +1,122 @@
+// Copy pasted and modified from this codepen: https://codepen.io/anthonygreco/pen/PGPVJz
+import gsap, {Physics2DPlugin} from "/scripts/greensock/esm/all.js";
+gsap.registerPlugin(Physics2DPlugin);
+
+var emitterSize = 20,
+dotQuantity = 120,
+dotSizeMin = 10,
+dotSizeMax = 15,
+speed = 10,
+gravity = 0.7,
+explosionQuantity = 6,
+emitter = document.querySelector('#interface'),
+explosions = [],
+currentExplosion = 0,
+container, i;
+
+function createExplosion(container) {
+  var tl = gsap.timeline({paused: true}),
+  dots = [],
+  angle, duration, length, dot, i, size, r, g, b;
+  for (i = 0; i < dotQuantity; i++) {
+    dot = document.createElement('div');
+    dots.push(dot);
+    dot.className = 'dramatic-rolls-dot';
+    r = getRandom(30, 255);
+    g = getRandom(30, 230);
+    b = getRandom(30, 230);
+    gsap.set(dot, {
+      backgroundColor: 'rgb('+r+','+g+','+b+')',
+      visibility: 'hidden'
+    });
+    size = getRandom(dotSizeMin, dotSizeMax);
+    container.appendChild(dot);
+    angle = getRandom(0.65, 0.85) * Math.PI * 2; // a vector pointed up
+    // get maximum distance from the center, factoring in size of dot, and then pick a random spot along that vector to plot a point
+    length = Math.random() * (emitterSize / 2 - size / 2);
+    duration = 8 + Math.random();
+    // place the dot at a random spot within the emitter, and set its size
+    gsap.set(dot, {
+      x: Math.cos(angle) * length, 
+      y: Math.sin(angle) * length, 
+      width: size, 
+      height: size, 
+      xPercent: -50, 
+      yPercent: -50,
+      visibility: 'hidden',
+      force3D: true
+    });
+    tl.to(dot, duration / 2, {
+      opacity: 0,
+      ease: 'rough'
+    }, 0).to(dot, {
+      duration: duration,
+      visibility: 'visible',
+      rotationX: '-='+getRandom(720, 1440),
+      rotationZ: '+='+getRandom(720, 1440),
+      physics2D: {
+        angle: angle * 180 / Math.PI, // translate radians to degrees
+        velocity: (100 + Math.random() * 250) * speed, // initial velocity
+        gravity: 700 * gravity,
+        friction: getRandom(0.1, 0.15)
+      }
+     }, 0).to(dot, 1.25 + Math.random(), {
+      opacity: 0
+    }, duration / 4);
+  }
+  // hide the dots at the end for improved performance (better than opacity: 0 because the browser can ignore the elements)
+  // console.log('setting', dots);
+  tl.set(dots, {visibility: 'hidden'});
+  return tl;
+}
+
+function explode(element) {
+  var bounds = element.getBoundingClientRect(),
+  explosion;
+  console.log(bounds)
+  if (++currentExplosion === explosions.length) {
+    currentExplosion = 0;
+  }
+  explosion = explosions[currentExplosion];
+  explosion.animation.set(explosion.container, {
+    x: bounds.left + bounds.width / 2,
+    y: bounds.top + bounds.height / 2
+  });
+  explosion.animation.restart();
+}
+
+function getRandom(min, max) {
+  var rand = min + Math.random() * (max - min);
+  return rand;
+}
+
+export function fireConfetti() {
+  var intervalCount = 0,
+  interval = setInterval(function() {
+    if (intervalCount < 5) {
+      explode(emitter);
+      intervalCount++;
+    } else {
+      clearInterval(interval);
+    }
+  }, 150);
+}
+
+export function setupConfetti() {
+   const parentContainer = document.createElement('div');
+   parentContainer.className = 'dramatic-rolls-confetti-emitter-container';
+   document.body.appendChild(parentContainer);
+  for (i = 0; i < explosionQuantity; i++) {
+    container = document.createElement('div');
+    container.className = 'dramatic-rolls-dot-container';
+    parentContainer.appendChild(container);
+    explosions.push({
+      container: container,
+      animation: createExplosion(container)
+    });
+  }
+    
+  document.querySelector('body').onclick = function () {
+   fireConfetti();
+  };
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -2,6 +2,7 @@ import soundEffectController from "./soundEffectController.js";
 import { registerSettings, registerConfettiSetting } from "./settings.js";
 import constants from "../constants.js";
 import { initRollCollection } from "./rollCollector.js";
+import { setupConfetti, fireConfetti } from "./confetti.js";
 
 Hooks.on("init", () => {
    registerSettings();
@@ -15,6 +16,7 @@ Hooks.on("ready", () => {
       registerConfettiSetting();
    }
    initRollCollection();
+   setupConfetti();
 });
 
 export const handleEffects = (roll, isPublic = true) => {
@@ -126,6 +128,8 @@ const playSound = (roll, broadcastSound) => {
 };
 
 const handleConfetti = (shouldBroadcastToOtherPlayers) => {
+   fireConfetti();
+
    try {
       if (game.settings.get(constants.modName, "add-confetti")) {
          const strength = window.confetti.confettiStrength.high;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,5 +1,5 @@
 import soundEffectController from "./soundEffectController.js";
-import { registerSettings, registerConfettiSetting } from "./settings.js";
+import { registerSettings } from "./settings.js";
 import constants from "../constants.js";
 import { initRollCollection } from "./rollCollector.js";
 import { setupConfetti, fireConfetti } from "./confetti.js";
@@ -14,12 +14,12 @@ Hooks.on("init", () => {
 });
 
 Hooks.on("ready", () => {
-   if (game.modules.get("confetti")?.active) {
-      registerConfettiSetting();
-   }
    initRollCollection();
    setupConfetti();
-   game.socket.on(socketName, fireConfetti);
+
+   if (game.settings.get(constants.modName, "add-confetti")) {
+      game.socket.on(socketName, fireConfetti);
+   }
 });
 
 export const handleEffects = (roll, isPublic = true) => {
@@ -131,26 +131,11 @@ const playSound = (roll, broadcastSound) => {
 };
 
 const handleConfetti = (shouldBroadcastToOtherPlayers) => {
-   fireConfetti();
+   if (game.settings.get(constants.modName, "add-confetti")) {
+      fireConfetti();
+   }
 
    if (shouldBroadcastToOtherPlayers) {
       game.socket.emit(socketName);
-   }
-
-   try {
-      if (game.settings.get(constants.modName, "add-confetti")) {
-         const strength = window.confetti.confettiStrength.high;
-         const shootConfettiProps =
-            window.confetti.getShootConfettiProps(strength);
-         mergeObject(shootConfettiProps, { sound: null });
-
-         if (shouldBroadcastToOtherPlayers) {
-            window.confetti.shootConfetti(shootConfettiProps);
-         } else {
-            window.confetti.handleShootConfetti(shootConfettiProps);
-         }
-      }
-   } catch {
-      // Oh well, means the confetti mod isn't installed
    }
 };

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4,6 +4,8 @@ import constants from "../constants.js";
 import { initRollCollection } from "./rollCollector.js";
 import { setupConfetti, fireConfetti } from "./confetti.js";
 
+const socketName = `module.${constants.modName}`;
+
 Hooks.on("init", () => {
    registerSettings();
    if (constants.debugMode) {
@@ -17,6 +19,7 @@ Hooks.on("ready", () => {
    }
    initRollCollection();
    setupConfetti();
+   game.socket.on(socketName, fireConfetti);
 });
 
 export const handleEffects = (roll, isPublic = true) => {
@@ -129,6 +132,10 @@ const playSound = (roll, broadcastSound) => {
 
 const handleConfetti = (shouldBroadcastToOtherPlayers) => {
    fireConfetti();
+
+   if (shouldBroadcastToOtherPlayers) {
+      game.socket.emit(socketName);
+   }
 
    try {
       if (game.settings.get(constants.modName, "add-confetti")) {

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -66,6 +66,16 @@ export const registerSettings = () => {
       type: Boolean,
    });
 
+   game.settings.register(constants.modName, "add-confetti", {
+      name: "dramatic-rolls.settings.add-confetti.name",
+      // hint: '',
+      scope: "world",
+      config: true,
+      default: true,
+      type: Boolean,
+      restricted: false
+   });
+
    if (game.system.id === "pf2e") {
       game.settings.register(
          constants.modName,
@@ -80,15 +90,4 @@ export const registerSettings = () => {
          }
       );
    }
-};
-
-export const registerConfettiSetting = () => {
-   game.settings.register(constants.modName, "add-confetti", {
-      name: "dramatic-rolls.settings.add-confetti.name",
-      // hint: '',
-      scope: "world",
-      config: true,
-      default: true,
-      type: Boolean,
-   });
 };

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -28,6 +28,7 @@ export const registerSettings = () => {
       scope: "world",
       config: true,
       default: true,
+      restricted: true,
       type: Boolean,
    });
 
@@ -46,6 +47,7 @@ export const registerSettings = () => {
       default: defaultSettings,
       type: Object,
       config: false,
+      restricted: true,
    });
 
    game.settings.register(constants.modName, "disable-npc-rolls", {
@@ -55,6 +57,7 @@ export const registerSettings = () => {
       config: true,
       default: false,
       type: Boolean,
+      restricted: true,
    });
 
    game.settings.register(constants.modName, "trigger-on-public-only", {
@@ -64,6 +67,7 @@ export const registerSettings = () => {
       config: true,
       default: false,
       type: Boolean,
+      restricted: true,
    });
 
    game.settings.register(constants.modName, "add-confetti", {
@@ -73,7 +77,7 @@ export const registerSettings = () => {
       config: true,
       default: true,
       type: Boolean,
-      restricted: false
+      restricted: false,
    });
 
    if (game.system.id === "pf2e") {
@@ -87,6 +91,7 @@ export const registerSettings = () => {
             config: true,
             default: false,
             type: Boolean,
+            restricted: true,
          }
       );
    }

--- a/styles/dramaticRolls.css
+++ b/styles/dramaticRolls.css
@@ -80,3 +80,23 @@
     display: none;
 }
 
+.dramatic-rolls-dot-container {
+   flex-grow: 1;
+   overflow:visible;
+   z-index:5000;
+   pointer-events:none;
+ }
+ .dramatic-rolls-dot {
+   position: absolute;
+   pointer-events: none; /*performance optimization*/
+ }
+
+ .dramatic-rolls-confetti-emitter-container {
+   height: 10px;
+   position: absolute;
+   bottom: 0;
+   width: 100%;
+   display: flex;
+   margin-left: 5rem;
+   margin-right: 5rem;
+ }


### PR DESCRIPTION
Adds support for confetti to be fired on criticals without the dependency on the depreciated confetti module. 