### PR TITLE
Add GURPS Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ For users of the Pathfinder 2e game system, Dramatic Rolls offers additional opt
 - Visual effects including confetti and more for critical hits
 - Compatible with Dice So Nice! module
 - Configurable settings to fine-tune your experience
-- Pathfinder 2e support: Trigger effects on critical successes and failures based on degree of success, not just natural 20s and 1s
+
+## Game Systems Support
+- Pathfinder 2e: Trigger effects on critical successes and failures based on degree of success, not just natural 20s and 1s
+- GURPS: Trigger effects on critical successes and failures based on GURPS 4e rules, only for 3d6 rolls with calculated margin of success/failure.
 
 ## Installation
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -4,6 +4,7 @@ import {
 } from "./settings/settings.js";
 import constants from "../constants.js";
 import { initRollCollection } from "./rollCollector.js";
+import { parseFromGurpsRoll } from "./utils.js";
 import animationController from "./controllers/animationController.js";
 
 Hooks.on("init", () => {
@@ -53,6 +54,9 @@ const getIsRollOverrideCrit = (roll) => {
    ) {
       return roll.options?.degreeOfSuccess === 3;
    }
+   if (game.system.id === "gurps") {
+      return parseFromGurpsRoll(roll).isCritSuccess
+   }
    return false;
 };
 
@@ -62,6 +66,9 @@ const getIsRollOverrideFumble = (roll) => {
       game.settings.get(constants.modName, "pf2e-trigger-on-degree-of-success")
    ) {
       return roll.options?.degreeOfSuccess === 0;
+   }
+   if (game.system.id === "gurps") {
+      return parseFromGurpsRoll(roll).isCritFailure
    }
    return false;
 };

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -12,3 +12,59 @@ export const getDistinct = (array, pick) => {
 export const getRandomArbitrary = (min, max) => {
    return Math.random() * (max - min) + min;
 };
+
+/*
+ * In GURPS critical success and failure are decided by specific results in 3d6 dice
+ * or by margin of success/failure.
+ *
+ * Critical success occur when:
+ *    1. The roll result is 4 or lower.
+ *    2. The roll result is 5 or 6, and the margin of success is 10 or more.
+ * Critical failure occur when:
+ *    1. The roll result is 18.
+ *    2. The roll result is 17, and the margin fails for -2 or more.
+ *    3. The roll result is 5 or more and the margin fails for more than -10.
+ *
+ * In GURPS Game Aid System, GurpsRoll stores the rolls inside GurpsDie and the margin
+ * is positive for success rolls or negative for failures. For rolls without a target number
+ * margin is undefined.
+ *
+ * Because we can use On-The-Fly formulas to roll dice,
+ * we need to check if the roll is a 3d6, if it has a valid flavor (internal reference
+ * for attributes, skills, spells, etc.) and a margin.
+ *
+ * @param {roll} - GurpsRoll object.
+ * @returns {Object} - An object containing the critical results
+ */
+export const parseFromGurpsRoll = (roll) => {
+   // Get GurpsDie and results from GurpsRoll
+   const gurpsDie = roll.dice[0]
+   const pureDiceResult = gurpsDie.values.reduce((acc, result) => acc + result, 0)
+   const numberOfDice = gurpsDie.values.length
+   const margin = roll.data.margin
+   const flavor = gurpsDie.flavor
+
+   // Check flavor
+   const ForbiddenFlavors = ["damage"]
+   const isValidFlavor = !!flavor && !ForbiddenFlavors.includes(flavor.toLowerCase())
+
+   let criticalSuccess = false
+   let criticalFailure = false
+
+   if (numberOfDice === 3 && isValidFlavor && !!margin) {
+      criticalSuccess = (
+          pureDiceResult <= 4 ||
+          (pureDiceResult <= 6 && margin >= 10)
+      )
+      criticalFailure = (
+          pureDiceResult === 18 ||
+          (pureDiceResult === 17 && margin <= -2) ||
+          (pureDiceResult > 4 && margin <= -10)
+      )
+   }
+
+   return {
+      isCritSuccess: criticalSuccess,
+      isCritFailure: criticalFailure,
+   }
+}


### PR DESCRIPTION
In GURPS critical success and failure are decided by specific results in 3d6 dice or by margin of success/failure.
 
## Critical Success
They occur when:
 1. The roll result is 4 or lower.
 2. The roll result is 5 or 6, and the margin of success is 10 or more.
## Critical Failure
 They occur when:
 1. The roll result is 18.
 2. The roll result is 17, and the margin fails for -2 or more.
 3. The roll result is 5 or more and the margin fails for more than -10.
 
 In GURPS Game Aid System, GurpsRoll stores the rolls inside GurpsDie and the margin  is positive for success rolls or negative for failures. For rolls without a target number margin is undefined.

Finally, because we can use [On-The-Fly formulas](https://docs.google.com/document/d/1NMBPt9KhA9aGG1_kZxyk8ncuOKhz9Z6o7vPS8JcjdWc/edit) to roll dice, we need to check if the roll is a 3d6, if it has a valid flavor (internal reference for attributes, skills, spells, etc.) and a margin.